### PR TITLE
Fix a bug with the filters in GetHealthChecksAsync()

### DIFF
--- a/WatchdogService/HealthCheckOperations.cs
+++ b/WatchdogService/HealthCheckOperations.cs
@@ -700,15 +700,15 @@ namespace Microsoft.ServiceFabric.WatchdogService
 
             if ((false == string.IsNullOrWhiteSpace(application)) && (false == string.IsNullOrWhiteSpace(service)) && (partition.HasValue))
             {
-                filter = $"fabric:/{application}/{service}/{partition}";
+                filter = $"/{application}/{service}/{partition}";
             }
             else if ((false == string.IsNullOrWhiteSpace(application)) && (false == string.IsNullOrWhiteSpace(service)))
             {
-                filter = $"fabric:/{application}/{service}";
+                filter = $"/{application}/{service}";
             }
             else if (false == string.IsNullOrWhiteSpace(application))
             {
-                filter = $"fabric:/{application}";
+                filter = $"/{application}";
             }
 
             try


### PR DESCRIPTION
remove the leading "fabric:" to allow the filters to work properly